### PR TITLE
fix android 14+ security exception

### DIFF
--- a/android/src/main/java/com/evanjmg/HomeWatcher.java
+++ b/android/src/main/java/com/evanjmg/HomeWatcher.java
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Build;
 import android.util.Log;
 
 public class HomeWatcher {
@@ -26,7 +27,11 @@ public class HomeWatcher {
 
     public void startWatch() {
         if (mRecevier != null) {
-            mContext.registerReceiver(mRecevier, mFilter);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                mContext.registerReceiver(mRecevier, mFilter, Context.RECEIVER_EXPORTED);
+            } else {
+                mContext.registerReceiver(mRecevier, mFilter);
+            }
         }
     }
 


### PR DESCRIPTION
Registering receivers with intention using the RECEIVER_EXPORTED / RECEIVER_NOT_EXPORTED flag was introduced as part of Android 13 and is now a requirement for apps running on Android 14 or higher (U+).

If we do not implement this, the system will throw a security exception.